### PR TITLE
Update dune for ppx_camlrack tests

### DIFF
--- a/ppx_camlrack/test/dune
+++ b/ppx_camlrack/test/dune
@@ -26,11 +26,13 @@
 (test
  (name test_sexp)
  (modules test_sexp)
+ (package ppx_camlrack)
  (libraries camlrack)
  (preprocess (pps ppx_camlrack)))
 
 (test
  (name test_spat)
  (modules test_spat)
+ (package ppx_camlrack)
  (libraries camlrack)
  (preprocess (pps ppx_camlrack)))


### PR DESCRIPTION
If you want to avoid the circular dependency, requiring the use of post (see the other PR), this change should be what you need